### PR TITLE
Fix broken menu items related to node creation

### DIFF
--- a/app/assets/javascripts/controller.js
+++ b/app/assets/javascripts/controller.js
@@ -169,6 +169,7 @@ Controller.prototype.createNode = function (uiNode, mode) {
  Create a new child of uiNode
  */
 Controller.prototype.createChild = function (uiNode) {
+  uiNode = uiNode || this.selectedNode
   uiNode.expand() // Make sure node is expanded before creating child, so that it will be visible.
   return this.createNode(uiNode, 'createChild');
 }
@@ -178,14 +179,14 @@ Controller.prototype.createChild = function (uiNode) {
  Create a new successor of uiNode
  */
 Controller.prototype.createSuccessor = function (uiNode) {
-  return this.createNode(uiNode, 'createSuccessor');
+  return this.createNode(uiNode || this.selectedNode, 'createSuccessor');
 }
 
 /*
  Create a new predecessor of uiNode
  */
 Controller.prototype.createPredecessor = function (uiNode) {
-  return this.createNode(uiNode, 'createPredecessor');
+  return this.createNode(uiNode || this.selectedNode, 'createPredecessor');
 }
 
 


### PR DESCRIPTION
Menu items for create child, create predecessor, create successor were failing because they do not a uiNode to the controller. That's okay, because they're menu items and there is a "selected node". But the controller should have been defaulting to the selected node and it was not.
